### PR TITLE
feat(Associations) [AS] Add :as option for polymorphic transition cla…

### DIFF
--- a/lib/state_machines/audit_trail/backend.rb
+++ b/lib/state_machines/audit_trail/backend.rb
@@ -1,4 +1,4 @@
-class StateMachines::AuditTrail::Backend < Struct.new(:transition_class, :owner_class, :context)
+class StateMachines::AuditTrail::Backend < Struct.new(:transition_class, :owner_class, :context, :options)
 
   autoload :Mongoid, 'state_machines/audit_trail/backend/mongoid'
   autoload :ActiveRecord, 'state_machines/audit_trail/backend/active_record'
@@ -38,11 +38,11 @@ class StateMachines::AuditTrail::Backend < Struct.new(:transition_class, :owner_
   # To add a new ORM, implement something similar to lib/state_machines/audit_trail/backend/active_record.rb
   # and return from here the appropriate object based on which ORM the transition_class is using
   #
-  def self.create_for(transition_class, owner_class, options = {})
+  def self.create_for(transition_class, owner_class, context = nil, options = {})
     if Object.const_defined?('ActiveRecord') && transition_class.ancestors.include?(::ActiveRecord::Base)
-      return StateMachines::AuditTrail::Backend::ActiveRecord.new(transition_class, owner_class, options)
+      return StateMachines::AuditTrail::Backend::ActiveRecord.new(transition_class, owner_class, context, options)
     elsif Object.const_defined?('Mongoid') && transition_class.ancestors.include?(::Mongoid::Document)
-      return StateMachines::AuditTrail::Backend::Mongoid.new(transition_class, owner_class, options)
+      return StateMachines::AuditTrail::Backend::Mongoid.new(transition_class, owner_class, context, options)
     else
       raise 'Not implemented. Only support for ActiveRecord and Mongoid is implemented. Pull requests welcome.'
     end

--- a/lib/state_machines/audit_trail/backend.rb
+++ b/lib/state_machines/audit_trail/backend.rb
@@ -38,11 +38,11 @@ class StateMachines::AuditTrail::Backend < Struct.new(:transition_class, :owner_
   # To add a new ORM, implement something similar to lib/state_machines/audit_trail/backend/active_record.rb
   # and return from here the appropriate object based on which ORM the transition_class is using
   #
-  def self.create_for(transition_class, owner_class, context = nil)
+  def self.create_for(transition_class, owner_class, options = {})
     if Object.const_defined?('ActiveRecord') && transition_class.ancestors.include?(::ActiveRecord::Base)
-      return StateMachines::AuditTrail::Backend::ActiveRecord.new(transition_class, owner_class, context)
+      return StateMachines::AuditTrail::Backend::ActiveRecord.new(transition_class, owner_class, options)
     elsif Object.const_defined?('Mongoid') && transition_class.ancestors.include?(::Mongoid::Document)
-      return StateMachines::AuditTrail::Backend::Mongoid.new(transition_class, owner_class, context)
+      return StateMachines::AuditTrail::Backend::Mongoid.new(transition_class, owner_class, options)
     else
       raise 'Not implemented. Only support for ActiveRecord and Mongoid is implemented. Pull requests welcome.'
     end

--- a/lib/state_machines/audit_trail/backend/active_record.rb
+++ b/lib/state_machines/audit_trail/backend/active_record.rb
@@ -3,11 +3,12 @@ require 'state_machines-activerecord'
 class StateMachines::AuditTrail::Backend::ActiveRecord < StateMachines::AuditTrail::Backend
   attr_accessor :context
 
-  def initialize(transition_class, owner_class, context = nil)
+  def initialize(transition_class, owner_class, options = {})
     @association = transition_class.to_s.tableize.split('/').last.to_sym
-    super transition_class, owner_class
-    self.context = context # FIXME: actually not sure why we need to do this, but tests fail otherwise. Something with super's Struct?
-    owner_class.has_many(@association, class_name: transition_class.to_s) unless owner_class.reflect_on_association(@association)
+    super transition_class, owner_class, options[:context]
+    # self.context = options[:context] # need to store in Struct field, otherwise `options` is just a local var and will be lost
+    assoc_options = {class_name: transition_class.to_s}.merge(options.slice(:as))
+    owner_class.has_many(@association, assoc_options) unless owner_class.reflect_on_association(@association)
   end
 
   def persist(object, fields)

--- a/lib/state_machines/audit_trail/backend/active_record.rb
+++ b/lib/state_machines/audit_trail/backend/active_record.rb
@@ -3,10 +3,9 @@ require 'state_machines-activerecord'
 class StateMachines::AuditTrail::Backend::ActiveRecord < StateMachines::AuditTrail::Backend
   attr_accessor :context
 
-  def initialize(transition_class, owner_class, options = {})
+  def initialize(transition_class, owner_class, context = nil, options = {})
     @association = transition_class.to_s.tableize.split('/').last.to_sym
-    super transition_class, owner_class, options[:context]
-    # self.context = options[:context] # need to store in Struct field, otherwise `options` is just a local var and will be lost
+    super
     assoc_options = {class_name: transition_class.to_s}.merge(options.slice(:as))
     owner_class.has_many(@association, assoc_options) unless owner_class.reflect_on_association(@association)
   end

--- a/lib/state_machines/audit_trail/transition_auditing.rb
+++ b/lib/state_machines/audit_trail/transition_auditing.rb
@@ -23,7 +23,7 @@ module StateMachines::AuditTrail::TransitionAuditing
     transition_class = options[:class] || default_transition_class
 
     # backend implements #log to store transition information
-    @backend = StateMachines::AuditTrail::Backend.create_for(transition_class, self.owner_class, options[:context])
+    @backend = StateMachines::AuditTrail::Backend.create_for(transition_class, self.owner_class, options.slice(:context, :as))
 
     # Initial state logging can be turned off. Very useful for a model with multiple state_machines using a single TransitionState object for logging
     unless options[:initial] == false

--- a/lib/state_machines/audit_trail/transition_auditing.rb
+++ b/lib/state_machines/audit_trail/transition_auditing.rb
@@ -23,7 +23,7 @@ module StateMachines::AuditTrail::TransitionAuditing
     transition_class = options[:class] || default_transition_class
 
     # backend implements #log to store transition information
-    @backend = StateMachines::AuditTrail::Backend.create_for(transition_class, self.owner_class, options.slice(:context, :as))
+    @backend = StateMachines::AuditTrail::Backend.create_for(transition_class, self.owner_class, options[:context], options.slice(:as))
 
     # Initial state logging can be turned off. Very useful for a model with multiple state_machines using a single TransitionState object for logging
     unless options[:initial] == false


### PR DESCRIPTION
…ss associations

I cannot get the mongoid spec tests to pass even on an untouched master, so I am open to feedback on anything that's missing there or how to get that to work.

The use case here is a module that is used across many classes that inserts a state machine into the including model as a requirement to manage dependencies amongst these models (e.g. transcoding various media assets and derivatives from source media). The audit trail is for debugging when something along this process goes wrong. Rather than leaving it to the developer of each new such asset to create an audit trail table correctly, I am aiming to use a single table for all transitions as a log of what happened with the entire set of service assets. Thus the declared association between the model and its state transitions must be declared as a polymorphic association using the `:as` keyword. I am uncertain how to build this into the generator, but adding `polymorphic: true` in the `references` line of the migration is all that is needed.

In my application with this branch, I use this feature simply with

`audit_trail class: ServiceAssetStateTransition, as: :service_asset`

in the module that gets included.
