### PR TITLE
feat(Associations) [AS] Add :as option for polymorphic transition cla…

### DIFF
--- a/lib/state_machines/audit_trail/backend/active_record.rb
+++ b/lib/state_machines/audit_trail/backend/active_record.rb
@@ -1,13 +1,11 @@
 require 'state_machines-activerecord'
 
 class StateMachines::AuditTrail::Backend::ActiveRecord < StateMachines::AuditTrail::Backend
-  attr_accessor :context
-
-  def initialize(transition_class, owner_class, context = nil)
+  def initialize(transition_class, owner_class, options = {})
+    super
     @association = transition_class.to_s.tableize.split('/').last.to_sym
-    super transition_class, owner_class
-    self.context = context # FIXME: actually not sure why we need to do this, but tests fail otherwise. Something with super's Struct?
-    owner_class.has_many(@association, class_name: transition_class.to_s) unless owner_class.reflect_on_association(@association)
+    assoc_options = {class_name: transition_class.to_s}.merge(options.slice(:as))
+    owner_class.has_many(@association, assoc_options) unless owner_class.reflect_on_association(@association)
   end
 
   def persist(object, fields)

--- a/lib/state_machines/audit_trail/transition_auditing.rb
+++ b/lib/state_machines/audit_trail/transition_auditing.rb
@@ -25,7 +25,7 @@ module StateMachines::AuditTrail::TransitionAuditing
     owner_class = options[:owner_class] || self.owner_class
 
     # backend implements #log to store transition information
-    @backend = StateMachines::AuditTrail::Backend.create_for(transition_class, owner_class, options[:context])
+    @backend = StateMachines::AuditTrail::Backend.create_for(transition_class, owner_class, options.slice(:context, :as))
 
     # Initial state logging can be turned off. Very useful for a model with multiple state_machines using a single TransitionState object for logging
     unless options[:initial] == false

--- a/spec/lib/state_machines/audit_trail/backend/active_record_spec.rb
+++ b/spec/lib/state_machines/audit_trail/backend/active_record_spec.rb
@@ -147,7 +147,7 @@ describe StateMachines::AuditTrail::Backend::ActiveRecord do
 
     context 'wants to log a single context' do
       before(:each) do
-        StateMachines::AuditTrail::Backend.create_for(ARModelWithContextStateTransition, ARModelWithContext, :context)
+        StateMachines::AuditTrail::Backend.create_for(ARModelWithContextStateTransition, ARModelWithContext, context: :context)
       end
 
       let!(:target) { ARModelWithContext.create! }
@@ -161,7 +161,7 @@ describe StateMachines::AuditTrail::Backend::ActiveRecord do
 
     context 'wants to log multiple context fields' do
       before(:each) do
-        StateMachines::AuditTrail::Backend.create_for(ARModelWithMultipleContextStateTransition, ARModelWithMultipleContext, [:context, :second_context, :context_with_args])
+        StateMachines::AuditTrail::Backend.create_for(ARModelWithMultipleContextStateTransition, ARModelWithMultipleContext, context: [:context, :second_context, :context_with_args])
       end
 
       let!(:target) { ARModelWithMultipleContext.create! }

--- a/spec/lib/state_machines/audit_trail/backend/active_record_spec.rb
+++ b/spec/lib/state_machines/audit_trail/backend/active_record_spec.rb
@@ -264,6 +264,19 @@ describe StateMachines::AuditTrail::Backend::ActiveRecord do
     end
   end
 
+  context 'polymorphic' do
+    it 'creates polymorphic state transitions' do
+      m1 = ARFirstModelWithPolymorphicStateTransition.create!
+      m2 = ARSecondModelWithPolymorphicStateTransition.create!
+      m2.start!
+      m2.finish!
+
+      expect(m1.ar_resource_state_transitions.count).to eq(1)
+      expect(m2.ar_resource_state_transitions.count).to eq(3)
+      expect(ARResourceStateTransition.count).to eq(4)
+    end
+  end
+
   private
 
   def assert_transition(state_transition, event, from, to)


### PR DESCRIPTION
…ss associations

Allows transition records to be defined as polymorphic associations. The use case driving this feature is a module/mixin that is used across multiple classes that defines a state machine for each including model. In this example, this allows multiple classes to mixin a common, state-machine-driven interface for an external user to interact with consistently.

An existing difficulty to adding an audit trail to this architecture is that each asset class needs to define its own audit trail model & table. By adding this feature, we allow all such state transitions to be stored in the same table, which allows the quick development of new asset classes within this architecture without the developer needing to worry about the audit trail (which in this use case is only used for debugging purposes anyway).

Note that I have not included any hook into this feature in the audit trail generator as I have not used the generator. It should be doable by adding `polymorphic: true` in the `t.references` call of the `create_table` block. 

As an example, declare an audit trail as polymorphic exactly as you would a Rails association: in a model referenced by `resource_type` and `resource_id`, simply use
`audit_trail class: ServiceAssetStateTransition, as: :resource`