### PR TITLE
Fix article link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for any state machine. Having an audit trail gives you a complete history of the
 to investigate incidents or perform analytics, like: _"How long does it take on average to go from state a to state b?"_,
 or _"What percentage of cases goes from state a to b via state c?"_
 
-For more information read [Why developers should be force-fed state machines](http://www.shopify.com/technology/3383012-why-developers-should-be-force-fed-state-machines).
+For more information read [Why developers should be force-fed state machines](https://engineering.shopify.com/17488160-why-developers-should-be-force-fed-state-machines).
 
 ## ORM support
 


### PR DESCRIPTION
This article link had become broken; I'm assuming this is a working link to the same article as previously (it's on the same blog and has the same title).