### PR TITLE
Remove nil fields so we do not force nil values into ORM

### DIFF
--- a/lib/state_machines/audit_trail/backend.rb
+++ b/lib/state_machines/audit_trail/backend.rb
@@ -17,7 +17,11 @@ class StateMachines::AuditTrail::Backend < Struct.new(:transition_class, :owner_
       # initial state open struct
       namespace = transition.namespace
     end
-    fields = {namespace: namespace, event: transition.event ? transition.event.to_s : nil, from: transition.from, to: transition.to}
+
+    fields = {
+      namespace: namespace, event: transition.event ? transition.event.to_s : nil, from: transition.from, to: transition.to
+    }.reject { |_, value| value.nil? }
+
     [*options[:context]].each { |field|
       fields[field] = resolve_context(object, field, transition)
     }

--- a/spec/lib/state_machines/audit_trail/backend_spec.rb
+++ b/spec/lib/state_machines/audit_trail/backend_spec.rb
@@ -1,0 +1,23 @@
+require 'state_machines'
+require 'spec_helper'
+require 'state_machines-activerecord'
+require 'helpers/active_record'
+
+describe StateMachines::AuditTrail::Backend do
+
+  context 'logging' do
+
+    it 'removes all nil attributes from fields' do
+      backend = StateMachines::AuditTrail::Backend.new(ARModelWithContextStateTransition, ARModel, {})
+
+      allow(StateMachines::AuditTrail::Backend).to receive(:new).and_return(backend)
+      allow(backend).to receive(:persist)
+
+      transition = OpenStruct.new(namespace: 'foo', from: nil, to: 'waiting', event: nil)
+
+      backend.log(ARModel.new, transition)
+
+      expect(backend).to have_received(:persist).with(ARModel, { namespace: 'foo', to: 'waiting' })
+    end
+  end
+end


### PR DESCRIPTION
This is usefull when not all features of SM are used; for example
one might opt out of namespaces and not have `namespace` column in the
audit log table. In this scenario current implementation will raise an
error