### PR TITLE
Change how the method arity is counted to be more robust

### DIFF
--- a/lib/state_machines/audit_trail/backend.rb
+++ b/lib/state_machines/audit_trail/backend.rb
@@ -68,7 +68,7 @@ class StateMachines::AuditTrail::Backend < Struct.new(:transition_class, :owner_
     skip_args = object.is_a?(::ActiveRecord::Base) && object.class.reflections.keys.include?(context.to_s)
     # ---------------
 
-    if object.method(context).arity != 0 && !skip_args
+    if object.method(context).arity == 1 && !skip_args
       object.send(context, transition)
     else
       object.send(context)


### PR DESCRIPTION
Hi everyone,

I'm using JRuby and it may have a bug where this `if` clause: `object.method(context).arity` returns `-1` instead of `0`...

Because it's easier to fix `audit_trail` than JRuby, I'd like to propose this fix.

I don't think the code works if the method arity is > 1, so I think it could be more robust to just validate that the method arity == 1.

WDYT ?