### PR TITLE
CI: Drop unused Travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 
 script: "bundle exec rake"


### PR DESCRIPTION
  - For details, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration