### PR TITLE
Ignore namespace column if not present

### DIFF
--- a/lib/state_machines/audit_trail/backend/active_record.rb
+++ b/lib/state_machines/audit_trail/backend/active_record.rb
@@ -9,6 +9,8 @@ class StateMachines::AuditTrail::Backend::ActiveRecord < StateMachines::AuditTra
   end
 
   def persist(object, fields)
+    fields.delete(:namespace) unless namespace_column_present?(object)
+
     # Let ActiveRecord manage the timestamp for us so it does the right thing with regards to timezones.
     if object.new_record?
       object.send(@association).build(fields)
@@ -17,5 +19,12 @@ class StateMachines::AuditTrail::Backend::ActiveRecord < StateMachines::AuditTra
     end
 
     nil
+  end
+
+  private
+
+  # Does the namespace column exist on the transition table for the provided object?
+  def namespace_column_present?(object)
+    object.class.reflect_on_association(@association).klass.column_names.include?('namespace')
   end
 end

--- a/spec/helpers/active_record.rb
+++ b/spec/helpers/active_record.rb
@@ -254,13 +254,13 @@ end
 create_model_table(ARModelWithNamespace, false, :foo_state)
 create_model_table(ARModelWithMultipleStateMachines, true)
 
-def create_transition_table(owner_class_name, state, add_context: false, polymorphic: false)
+def create_transition_table(owner_class_name, state, add_context: false, polymorphic: false, add_namespace: false)
   class_name = "#{owner_class_name}#{state.to_s.camelize}Transition"
   ActiveRecord::Base.connection.create_table(class_name.tableize) do |t|
 
     t.references "#{owner_class_name.demodulize.underscore}", index: false, polymorphic: polymorphic
     # t.integer owner_class_name.foreign_key
-    t.string :namespace
+    t.string :namespace if add_namespace
     t.string :event
     t.string :from
     t.string :to
@@ -276,7 +276,7 @@ end
   create_transition_table(name, :state)
 end
 
-create_transition_table("ARModelWithNamespace", :foo_state, add_context: false)
+create_transition_table("ARModelWithNamespace", :foo_state, add_namespace: true)
 create_transition_table("ARModelWithContext", :state, add_context: true)
 create_transition_table("ARModelWithMultipleContext", :state, add_context: true)
 create_transition_table("ARModelWithMultipleStateMachines", :first)

--- a/spec/lib/state_machines/audit_trail/backend/active_record_spec.rb
+++ b/spec/lib/state_machines/audit_trail/backend/active_record_spec.rb
@@ -67,12 +67,11 @@ describe StateMachines::AuditTrail::Backend::ActiveRecord do
       expect(state_transition.event).to be_nil
     end
 
-    it 'should not log namespace' do
+    it 'should not log namespace if namespace column doesn\'t exist' do
       target = ARModel.create!
       expect(target.new_record?).to be_falsey
       expect(target.ar_model_state_transitions.count).to eq 1
       state_transition = target.ar_model_state_transitions.first
-      expect(state_transition.namespace).to be_nil
       expect(state_transition.from).to be_nil
       expect(state_transition.to).to eq 'waiting'
       expect(state_transition.event).to be_nil


### PR DESCRIPTION
Fixes #15.

Don't attempt to save to the namespace column on the transition table if it doesn't exist.