### PR TITLE
Destroy transitions when resource id destroy

### DIFF
--- a/lib/state_machines/audit_trail/backend/active_record.rb
+++ b/lib/state_machines/audit_trail/backend/active_record.rb
@@ -4,7 +4,10 @@ class StateMachines::AuditTrail::Backend::ActiveRecord < StateMachines::AuditTra
   def initialize(transition_class, owner_class, options = {})
     super
     @association = transition_class.to_s.tableize.split('/').last.to_sym
-    assoc_options = {class_name: transition_class.to_s}.merge(options.slice(:as))
+    assoc_options = {
+      class_name: transition_class.to_s,
+      dependent: :destroy
+    }.merge(options.slice(:as, :dependent))
     owner_class.has_many(@association, assoc_options) unless owner_class.reflect_on_association(@association)
   end
 


### PR DESCRIPTION
Fix this issue https://github.com/state-machines/state_machines-audit_trail/issues/14