### PR TITLE
Test against Ruby 2.7 and fix a warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
   - jruby-head
   - jruby
@@ -18,9 +19,16 @@ gemfile:
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
+  - gemfiles/rails_6.0.gemfile
   - gemfiles/rails_edge.gemfile
 matrix:
   exclude:
+    - rvm: 2.2
+      gemfile: gemfiles/rails_6.0.gemfile
+    - rvm: 2.3
+      gemfile: gemfiles/rails_6.0.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_6.0.gemfile
     - rvm: 2.2
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.3

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0"
-gem "activemodel", "~> 5.0"
+gem "activerecord", "~> 5.0.0"
+gem "activemodel", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.1"
-gem "activemodel", "~> 5.1"
+gem "activerecord", "~> 5.1.0"
+gem "activemodel", "~> 5.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
-gem "activemodel", "~> 5.2.0"
+gem "activerecord", "~> 6.0.0"
+gem "activemodel", "~> 6.0.0"
 
 gemspec path: "../"

--- a/lib/state_machines/audit_trail/backend/active_record.rb
+++ b/lib/state_machines/audit_trail/backend/active_record.rb
@@ -5,7 +5,7 @@ class StateMachines::AuditTrail::Backend::ActiveRecord < StateMachines::AuditTra
     super
     @association = transition_class.to_s.tableize.split('/').last.to_sym
     assoc_options = {class_name: transition_class.to_s}.merge(options.slice(:as))
-    owner_class.has_many(@association, assoc_options) unless owner_class.reflect_on_association(@association)
+    owner_class.has_many(@association, **assoc_options) unless owner_class.reflect_on_association(@association)
   end
 
   def persist(object, fields)


### PR DESCRIPTION
Fixes the following warning, which is the only 2.7 warning actually coming from `state_machines-audit_trail`:

```
/tmp/bundle/ruby/2.7.0/gems/state_machines-audit_trail-2.0.1/lib/state_machines/audit_trail/backend/active_record.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/bundle/ruby/2.7.0/bundler/gems/rails-a47e0c19e60b/activerecord/lib/active_record/associations.rb:1425: warning: The called method `has_many' is defined here
```

cc @rafaelfranca @seuros @olleolleolle @smudge 