### PR TITLE
Update Shopify blog post link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for any state machine. Having an audit trail gives you a complete history of the
 to investigate incidents or perform analytics, like: _"How long does it take on average to go from state a to state b?"_,
 or _"What percentage of cases goes from state a to b via state c?"_
 
-For more information read [Why developers should be force-fed state machines](https://engineering.shopify.com/blogs/engineering/17488160-why-developers-should-be-force-fed-state-machines).
+For more information read [Why developers should be force-fed state machines](https://engineering.shopify.com/17488160-why-developers-should-be-force-fed-state-machines).
 
 ## ORM support
 


### PR DESCRIPTION
The current link to the ["Why developers should be force-fed state machines"](https://engineering.shopify.com/blogs/engineering/17488160-why-developers-should-be-force-fed-state-machines) article goes to a 404 page.

This PR updates the link with [the latest working URL](https://shopify.engineering/17488160-why-developers-should-be-force-fed-state-machines#) for the post.
