### PR TITLE
chore: test Ruby 3.4 and 4.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4']
+        ruby-version: ['3.4', '4.0']
         gemfiles:
           - gemfiles/rails_7.1.gemfile
           - gemfiles/rails_7.2.gemfile


### PR DESCRIPTION
Update CI matrix to test Ruby 3.4 and 4.0 only.